### PR TITLE
⏫ Gitpod uses "latest"

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: drupalpod/drupalpod-gitpod-base:20230922
+image: drupalpod/drupalpod-gitpod-base:latest
 
 # DDEV and composer are running as part of the prebuild
 # when starting a workspace all docker images are ready


### PR DESCRIPTION
Use "latest" for Gitpod image.
Fixes prebuild issues